### PR TITLE
Update the styles of the calendar. Add shorter weekday names for mobile devices.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,15 @@
 // @import "bootstrap-sprockets";
 @import "bootstrap";
 
+// block styles
+@import "./block/*";
+
+// element styles
+@import "./element/*";
+
+// Calendar style
+@import "./calendar/*";
+
 .day-working { background-color: $yellow; }
 .day-free { background-color: $green; }
 .day-things { background-color: $gray-500; }

--- a/app/assets/stylesheets/block/_container.scss
+++ b/app/assets/stylesheets/block/_container.scss
@@ -1,0 +1,4 @@
+._container{
+  width: 100%;
+  height: 100%;
+}

--- a/app/assets/stylesheets/calendar/week-days.scss
+++ b/app/assets/stylesheets/calendar/week-days.scss
@@ -1,0 +1,12 @@
+.full-name{
+  @media(max-width: 991px){
+    display: none;
+  }
+}
+
+.short-name{
+  display: none;
+  @media(max-width: 991px){
+    display: block;
+  }
+}

--- a/app/assets/stylesheets/element/flex-container.scss
+++ b/app/assets/stylesheets/element/flex-container.scss
@@ -1,0 +1,5 @@
+.date__flex-container{
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/app/assets/stylesheets/element/grid-containers.scss
+++ b/app/assets/stylesheets/element/grid-containers.scss
@@ -1,0 +1,4 @@
+.week-days__grid-container{
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+}

--- a/app/views/team_days/index.html.haml
+++ b/app/views/team_days/index.html.haml
@@ -11,17 +11,20 @@
 
 %p
 
-.row
+.week-days__grid-container
+  - short_week_days = { "понедельник" => "ПН", "вторник" => "ВТ", "среда" => "СР", "четверг" => "ЧТ", "пятница" => "ПТ", "суббота" => "СБ", "воскресенье" => "ВС" }
   - week_days(mon_first: true).each do |day_name|
-    .col.text-center.border.bg-light
+    .col.text-center.border.bg-light.full-name
       = day_name
+    .col.text-center.border.bg-light.short-name
+      = short_week_days[day_name]
 
 - selected_days_by_weeks.each do |row|
-  .row
+  .week-days__grid-container
     - row.each do |date|
-      .col.border
+      .col.border.date__flex-container
         - if date
-          .row
+          .row.date__container._container
             .col
               %h5= date.day
             .col


### PR DESCRIPTION
Changing the land weekday names to a shorter version for devices with a width of 991 pixels or less. Also, making some small style changes to improve the visual experience on mobile devices. 