### PR TITLE
Raise up session expiry date to 7 days

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :cookie_store, key: '_holy_session', expire_after: 7.days


### PR DESCRIPTION
The session was forgotten after each browser was closed. I had to write the password over and over again. Now the session is forgotten after 7 days.